### PR TITLE
Using python server directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Here we call the conversion function. Parameters are :
 ### How to run the exporter: 
 
 Two main steps :
-  * execute run.sh to start a local web server on your PC serving your freshly created `export.html` file
+  * execute `run` to start a local web server on your PC serving your freshly created `export.html` file
   * point your browser to [http://localhost:8000/export.html](http://localhost:8000/export.html)
   
 That's it, you should be able to download the GLFT resulting file.

--- a/run
+++ b/run
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import http.server
+import socketserver
+
+port = 8000
+
+handler = http.server.SimpleHTTPRequestHandler
+
+with socketserver.TCPServer(('', port), handler) as httpd:
+    print('Started http server to serve requests at:')
+    print('http://127.0.0.1:' + str(port))
+    httpd.serve_forever()

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "Started http server to serve requests"
-python3 -m http.server &


### PR DESCRIPTION
The `run.sh` script starts python server.
The change runs python server directly, this does not leave process in the background when the script is exited.
@sponce 